### PR TITLE
feat: Add global Open Graph tags

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,6 +21,19 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "Next Generation of Analytics | AnalyticsFlow",
   description: "Data Analytical service with focus on making companies better",
+  openGraph: {
+    title: "Next Generation of Analytics | AnalyticsFlow",
+    description: "Data Analytical service with focus on making companies better",
+    url: "https://analyticsflow.cz",
+    type: "website",
+    images: [
+      {
+        url: "/data_main_photo.jpeg",
+      },
+    ],
+    siteName: "AnalyticsFlow",
+    locale: "en_US",
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
I've added Open Graph meta tags to the global layout (`app/layout.tsx`) to improve how your content is shared and to boost its SEO.

Here are the OG tags I've included:
- og:title (uses your existing site title)
- og:description (uses your existing site description)
- og:url (set to https://analyticsflow.cz)
- og:type (set to 'website')
- og:image (set to '/data_main_photo.jpeg')
- og:site_name (set to 'AnalyticsFlow')
- og:locale (set to 'en_US')

These tags will now apply to all pages. Your blog section will inherit these tags; any specific overrides or exclusions for the blog can be addressed in future updates by modifying the blog's own metadata.