### PR TITLE
feat: Implement granular cookie consent modal

### DIFF
--- a/components/ConsentManager.tsx
+++ b/components/ConsentManager.tsx
@@ -1,0 +1,64 @@
+// components/ConsentManager.tsx
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import CookieConsentBanner from './CookieConsentBanner';
+import {
+  hasMadeConsentChoice,
+  getConsentPreferences,
+  ConsentPreferences,
+  COOKIE_VERSION,
+  defaultConsent
+} from '../lib/cookieConsentUtils';
+
+interface ConsentManagerProps {
+  children: React.ReactNode;
+}
+
+const ConsentManager: React.FC<ConsentManagerProps> = ({ children }) => {
+  const [showBanner, setShowBanner] = useState(false);
+  const [currentPreferences, setCurrentPreferences] = useState<ConsentPreferences>(defaultConsent);
+
+  useEffect(() => {
+    // This effect runs only on the client
+    const initialPrefs = getConsentPreferences();
+    setCurrentPreferences(initialPrefs);
+
+    const alreadyMadeChoice = hasMadeConsentChoice();
+    const consentVersionMatch = initialPrefs.version === COOKIE_VERSION;
+
+    if (!alreadyMadeChoice || !consentVersionMatch) {
+      setShowBanner(true);
+      if (!consentVersionMatch && alreadyMadeChoice) {
+        // If versions mismatch but a choice was made, it implies an old cookie.
+        // We load default new preferences to be shown in the customization modal.
+        setCurrentPreferences(defaultConsent);
+        console.log('Cookie consent version mismatch or structure outdated. Prompting for new consent.');
+      } else if (!alreadyMadeChoice) {
+        // No choice made at all, ensure defaults are set for the banner
+        setCurrentPreferences(defaultConsent);
+      }
+    }
+  }, []);
+
+  const handleConsentGiven = () => {
+    setShowBanner(false);
+    // Optionally, re-fetch preferences to ensure UI consistency if needed elsewhere,
+    // but banner actions already save and update state internally.
+    // setCurrentPreferences(getConsentPreferences());
+  };
+
+  return (
+    <>
+      {children}
+      {showBanner && (
+        <CookieConsentBanner
+          onConsentGiven={handleConsentGiven}
+          initialPreferences={currentPreferences}
+        />
+      )}
+    </>
+  );
+};
+
+export default ConsentManager;

--- a/components/CookieCustomizationModal.tsx
+++ b/components/CookieCustomizationModal.tsx
@@ -1,0 +1,267 @@
+// components/CookieCustomizationModal.tsx
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { ConsentPreferences, defaultConsent as defaultConsentValues } from '../lib/cookieConsentUtils';
+
+interface CookieCustomizationModalProps {
+  initialPreferences: ConsentPreferences;
+  onSave: (preferences: ConsentPreferences) => void;
+  onAcceptAll: () => void;
+  onRejectAll: () => void;
+  onClose: () => void;
+  isVisible: boolean;
+}
+
+// Basic styling (can be moved to CSS files/modules)
+const overlayStyles: React.CSSProperties = {
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  backgroundColor: 'rgba(0, 0, 0, 0.7)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 2001, // Higher than the main banner
+  padding: '20px',
+};
+
+const modalStyles: React.CSSProperties = {
+  backgroundColor: '#fff',
+  padding: '30px',
+  borderRadius: '8px',
+  boxShadow: '0 5px 15px rgba(0,0,0,0.3)',
+  maxWidth: '600px',
+  width: '100%',
+  maxHeight: '90vh',
+  overflowY: 'auto',
+  textAlign: 'left',
+};
+
+const toggleContainerStyles: React.CSSProperties = {
+  marginBottom: '20px',
+  padding: '15px',
+  border: '1px solid #eee',
+  borderRadius: '6px',
+};
+
+const toggleLabelStyles: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  fontWeight: '600',
+  fontSize: '17px',
+  marginBottom: '5px',
+};
+
+const toggleDescriptionStyles: React.CSSProperties = {
+  fontSize: '14px',
+  color: '#555',
+  marginBottom: '10px',
+};
+
+const switchStyles: React.CSSProperties = {
+  position: 'relative',
+  display: 'inline-block',
+  width: '50px',
+  height: '28px',
+};
+
+const switchInputStyles: React.CSSProperties = {
+  opacity: 0,
+  width: 0,
+  height: 0,
+};
+
+const sliderStyles: (isChecked: boolean) => React.CSSProperties = (isChecked) => ({
+  position: 'absolute',
+  cursor: 'pointer',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  backgroundColor: isChecked ? '#0070f3' : '#ccc',
+  transition: '.4s',
+  borderRadius: '28px',
+});
+
+const sliderBeforeStyles: (isChecked: boolean) => React.CSSProperties = (isChecked) => ({
+  position: 'absolute',
+  content: '""',
+  height: '20px',
+  width: '20px',
+  left: '4px',
+  bottom: '4px',
+  backgroundColor: 'white',
+  transition: '.4s',
+  borderRadius: '50%',
+  transform: isChecked ? 'translateX(22px)' : 'translateX(0)',
+});
+
+
+const buttonContainerStyles: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  marginTop: '25px',
+  gap: '10px',
+  flexWrap: 'wrap',
+};
+
+const buttonStyles: React.CSSProperties = {
+  padding: '10px 20px',
+  borderRadius: '5px',
+  border: 'none',
+  cursor: 'pointer',
+  fontSize: '15px',
+  fontWeight: '500',
+};
+
+const primaryButtonStyles: React.CSSProperties = { ...buttonStyles, backgroundColor: '#0070f3', color: 'white' };
+const secondaryButtonStyles: React.CSSProperties = { ...buttonStyles, backgroundColor: '#6c757d', color: 'white' };
+const tertiaryButtonStyles: React.CSSProperties = { ...buttonStyles, backgroundColor: '#e9ecef', color: '#212529' };
+
+
+const CookieCustomizationModal: React.FC<CookieCustomizationModalProps> = ({
+  initialPreferences,
+  onSave,
+  onAcceptAll,
+  onRejectAll,
+  onClose,
+  isVisible,
+}) => {
+  const [analyticsConsent, setAnalyticsConsent] = useState(initialPreferences.analytics);
+  const [marketingConsent, setMarketingConsent] = useState(initialPreferences.marketing);
+  const [preferencesConsent, setPreferencesConsent] = useState(initialPreferences.preferences);
+
+  useEffect(() => {
+    setAnalyticsConsent(initialPreferences.analytics);
+    setMarketingConsent(initialPreferences.marketing);
+    setPreferencesConsent(initialPreferences.preferences);
+  }, [initialPreferences]);
+
+  if (!isVisible) {
+    return null;
+  }
+
+  const handleSave = () => {
+    onSave({
+      ...initialPreferences, // Preserves version, timestamp (will be updated by saveConsentPreferences), essential
+      analytics: analyticsConsent,
+      marketing: marketingConsent,
+      preferences: preferencesConsent,
+    });
+  };
+
+  const handleAcceptAllClick = () => {
+    setAnalyticsConsent(true);
+    setMarketingConsent(true);
+    setPreferencesConsent(true);
+    onAcceptAll(); // This will save the fully accepted state via cookieConsentUtils
+  };
+
+  const handleRejectAllClick = () => {
+    setAnalyticsConsent(false);
+    setMarketingConsent(false);
+    setPreferencesConsent(false);
+    onRejectAll(); // This will save the fully rejected state via cookieConsentUtils
+  };
+
+
+  interface ToggleProps {
+    id: string;
+    label: string;
+    description: string;
+    isChecked: boolean;
+    onChange: (isChecked: boolean) => void;
+    disabled?: boolean;
+  }
+
+  const ConsentToggle: React.FC<ToggleProps> = ({ id, label, description, isChecked, onChange, disabled }) => (
+    <div style={toggleContainerStyles}>
+      <div style={toggleLabelStyles}>
+        <span>{label}</span>
+        <label style={switchStyles} htmlFor={id}>
+          <input
+            type="checkbox"
+            id={id}
+            style={switchInputStyles}
+            checked={isChecked}
+            onChange={(e) => !disabled && onChange(e.target.checked)}
+            disabled={disabled}
+          />
+          <span style={sliderStyles(isChecked)}>
+            <span style={sliderBeforeStyles(isChecked)}></span>
+          </span>
+        </label>
+      </div>
+      <p style={toggleDescriptionStyles}>{description}</p>
+    </div>
+  );
+
+  return (
+    <div style={overlayStyles} onClick={onClose}>
+      <div style={modalStyles} onClick={(e) => e.stopPropagation()}>
+        <h2 style={{ fontSize: '22px', fontWeight: '600', marginBottom: '10px', textAlign: 'center' }}>
+          Přizpůsobit nastavení cookies
+        </h2>
+        <p style={{ fontSize: '15px', color: '#333', marginBottom: '20px', lineHeight: '1.6' }}>
+          Spravujte své preference pro soubory cookie. Můžete povolit nebo zakázat různé kategorie cookies. Nezbytné cookies jsou vždy aktivní pro zajištění funkčnosti webu.
+        </p>
+
+        <ConsentToggle
+          id="essential"
+          label="Nezbytné cookies"
+          description="Tyto cookies jsou nutné pro základní funkce webu, jako je navigace, zabezpečení a dostupnost. Nelze je zakázat."
+          isChecked={true}
+          onChange={() => {}} // No-op
+          disabled={true}
+        />
+
+        <ConsentToggle
+          id="analytics"
+          label="Analytické cookies"
+          description="Pomáhají nám porozumět, jak návštěvníci používají naše stránky, sběrem a reportováním anonymních informací. Umožňují nám zlepšovat web."
+          isChecked={analyticsConsent}
+          onChange={setAnalyticsConsent}
+        />
+
+        <ConsentToggle
+          id="marketing"
+          label="Marketingové cookies"
+          description="Používají se ke sledování návštěvníků napříč webovými stránkami s cílem zobrazovat relevantnější a poutavější reklamy."
+          isChecked={marketingConsent}
+          onChange={setMarketingConsent}
+        />
+
+        <ConsentToggle
+          id="preferences"
+          label="Preferenční cookies"
+          description="Umožňují webu pamatovat si informace, které mění jeho chování nebo vzhled, například preferovaný jazyk nebo region."
+          isChecked={preferencesConsent}
+          onChange={setPreferencesConsent}
+        />
+
+        <div style={buttonContainerStyles}>
+          <button style={tertiaryButtonStyles} onClick={handleRejectAllClick}>
+            Odmítnout vše
+          </button>
+          <button style={primaryButtonStyles} onClick={handleSave}>
+            Uložit nastavení
+          </button>
+          <button style={secondaryButtonStyles} onClick={handleAcceptAllClick}>
+            Povolit vše
+          </button>
+        </div>
+         <button
+            onClick={onClose}
+            style={{...buttonStyles, backgroundColor: 'transparent', color: '#0070f3', marginTop: '15px', display: 'block', marginLeft: 'auto', marginRight: 'auto'}}>
+            Zavřít
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default CookieCustomizationModal;

--- a/lib/cookieConsentUtils.ts
+++ b/lib/cookieConsentUtils.ts
@@ -102,7 +102,7 @@ export const hasMadeConsentChoice = (): boolean => {
     // For safety, returning false as if no choice has been made server-side.
     return false;
   }
-  return hasCookie(CONSENT_COOKIE_NAME); // This will be boolean on client
+  return hasCookie(CONSENT_COOKIE_NAME) as boolean; // Explicit type assertion
 };
 
 /**

--- a/lib/cookieConsentUtils.ts
+++ b/lib/cookieConsentUtils.ts
@@ -2,20 +2,25 @@
 import { setCookie, getCookie, hasCookie } from 'cookies-next';
 
 export const CONSENT_COOKIE_NAME = 'user_consent_preferences';
-export const COOKIE_VERSION = '1.0'; // Versioning for future updates
+export const COOKIE_VERSION = '2.0'; // Updated version for new structure
 
 export interface ConsentPreferences {
-  version: string; // Version of the consent structure/banner
-  timestamp: number; // When the consent was given
-  analytics: boolean; // Example category: true if analytics allowed, false otherwise
-  // Add other categories here as needed, e.g., marketing: boolean;
+  version: string;
+  timestamp: number;
+  essential: true; // Essential cookies are always active and cannot be disabled
+  analytics: boolean;
+  marketing: boolean;
+  preferences: boolean;
 }
 
-// Default consent: typically all denied until explicitly accepted
+// Default consent: essential is true, others are false until explicitly accepted.
 export const defaultConsent: ConsentPreferences = {
   version: COOKIE_VERSION,
   timestamp: 0,
+  essential: true,
   analytics: false,
+  marketing: false,
+  preferences: false,
 };
 
 /**
@@ -50,58 +55,68 @@ export const getConsentPreferences = (): ConsentPreferences => {
   if (cookieValue && typeof cookieValue === 'string') {
     try {
       const parsed = JSON.parse(cookieValue) as Partial<ConsentPreferences>;
-      // Basic validation: check if it has an analytics property and a version.
-      // More robust validation might be needed for version migrations.
-      if (typeof parsed.analytics === 'boolean' && parsed.version) {
-        // If old version, could potentially migrate or reset to default.
-        // For now, if version doesn't match, we could reset to default or handle migration.
-        // Let's assume for now that any valid cookie with a version is acceptable,
-        // or we can enforce version match:
-        if (parsed.version !== COOKIE_VERSION) {
-            // If versions mismatch, it might be safer to return default consent,
-            // forcing re-consent for the new banner version.
-            // Or, implement a migration strategy. For now, let's re-evaluate.
-            // For simplicity in this step, if there's a cookie, we'll assume it's valid enough
-            // and the banner logic itself will handle if re-prompt is needed based on version.
-            // A more robust approach would be to clear old versions or migrate.
-            // Let's just return default if version is not current.
-             return { ...defaultConsent, ...parsed, version: parsed.version || COOKIE_VERSION };
-        }
-        return { ...defaultConsent, ...parsed };
+
+      // If the cookie version does not match the current version,
+      // or if essential fields are missing, return default to force re-consent.
+      if (
+        parsed.version !== COOKIE_VERSION ||
+        typeof parsed.analytics !== 'boolean' || // Check one of the new fields
+        typeof parsed.marketing !== 'boolean' || // Check another new field
+        typeof parsed.preferences !== 'boolean' // Check another new field
+      ) {
+        // Versions mismatch or structure is old/invalid, force re-consent by returning defaults.
+        // No need to save default consent here, the banner will prompt for new choices.
+        return { ...defaultConsent, timestamp: 0 }; // Reset timestamp too
       }
+
+      // If version matches and structure seems valid, return the parsed preferences,
+      // ensuring essential is always true.
+      return {
+        ...defaultConsent, // Provides defaults for any potentially missing non-critical fields
+        ...parsed,
+        essential: true, // Ensure essential is always true, regardless of what's in cookie
+        version: COOKIE_VERSION, // Ensure version is current
+      };
     } catch (error) {
       console.error('Error parsing consent cookie:', error);
-      // Fall through to return default consent
+      // Fall through to return default consent, forcing re-consent.
     }
   }
-  return { ...defaultConsent, timestamp: 0 }; // Ensure timestamp is 0 if no valid cookie
+  // No cookie found or error in parsing, return default to force consent.
+  return { ...defaultConsent, timestamp: 0 };
 };
 
 /**
  * Checks if the user has already made a consent choice (i.e., the consent cookie exists).
  * This doesn't validate the content, just presence.
+ * IMPORTANT: This function is intended for client-side use only, as `hasCookie`
+ * from `cookies-next` returns a boolean synchronously on the client.
  * @returns True if the consent cookie exists, false otherwise.
  */
 export const hasMadeConsentChoice = (): boolean => {
-  // On the server side, we check if we have the cookie value instead
+  // On the client, hasCookie returns boolean.
+  // Add a check for window to be explicit about client-side execution.
   if (typeof window === 'undefined') {
-    const cookieValue = getCookie(CONSENT_COOKIE_NAME);
-    return cookieValue !== undefined && cookieValue !== null;
+    // This case should ideally not happen if called correctly from client-side logic.
+    // Returning false or throwing an error might be options.
+    // For safety, returning false as if no choice has been made server-side.
+    return false;
   }
-  // On the client, hasCookie returns boolean synchronously
-  const result = hasCookie(CONSENT_COOKIE_NAME);
-  // Ensure we return boolean even if hasCookie might return Promise in some cases
-  return typeof result === 'boolean' ? result : false;
+  return hasCookie(CONSENT_COOKIE_NAME); // This will be boolean on client
 };
 
 /**
- * Helper function to grant consent for all categories (currently just analytics).
+ * Helper function to grant consent for all non-essential categories.
+ * Essential cookies remain true.
  */
 export const grantAllConsent = (): ConsentPreferences => {
   const newPreferences: ConsentPreferences = {
-    ...defaultConsent,
+    ...defaultConsent, // Includes essential: true, version, and timestamp placeholder
     analytics: true,
-    timestamp: Date.now(),
+    marketing: true,
+    preferences: true,
+    timestamp: Date.now(), // Overwrite timestamp
+    version: COOKIE_VERSION, // Ensure current version
   };
   saveConsentPreferences(newPreferences);
   return newPreferences;
@@ -109,12 +124,16 @@ export const grantAllConsent = (): ConsentPreferences => {
 
 /**
  * Helper function to reject all non-essential categories.
+ * Essential cookies remain true.
  */
 export const rejectAllConsent = (): ConsentPreferences => {
   const newPreferences: ConsentPreferences = {
-    ...defaultConsent,
-    analytics: false, // Explicitly set analytics to false
-    timestamp: Date.now(),
+    ...defaultConsent, // Includes essential: true, version, and timestamp placeholder
+    analytics: false,
+    marketing: false,
+    preferences: false,
+    timestamp: Date.now(), // Overwrite timestamp
+    version: COOKIE_VERSION, // Ensure current version
   };
   saveConsentPreferences(newPreferences);
   return newPreferences;

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://www.analyticsflow.cz</loc>
-    <lastmod>2025-06-29T19:42:04.000Z</lastmod>
+    <lastmod>2025-05-26T11:51:05.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -56,7 +56,7 @@
   </url>
   <url>
     <loc>https://www.analyticsflow.cz/cookies</loc>
-    <lastmod>2025-06-29T19:04:45.000Z</lastmod>
+    <lastmod>2025-05-23T12:49:37.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
@@ -68,37 +68,31 @@
   </url>
   <url>
     <loc>https://www.analyticsflow.cz/kontakt</loc>
-    <lastmod>2025-06-29T19:42:04.000Z</lastmod>
+    <lastmod>2025-05-26T11:34:23.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.analyticsflow.cz/o-nas</loc>
-    <lastmod>2025-06-29T19:42:04.000Z</lastmod>
+    <lastmod>2025-05-23T12:49:37.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.analyticsflow.cz/ochrana-soukromi</loc>
-    <lastmod>2025-06-29T19:42:04.000Z</lastmod>
+    <lastmod>2025-05-23T12:49:37.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://www.analyticsflow.cz/podminky</loc>
-    <lastmod>2025-06-29T19:42:04.000Z</lastmod>
+    <lastmod>2025-05-23T12:49:37.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://www.analyticsflow.cz/reference</loc>
-    <lastmod>2025-06-29T19:42:04.000Z</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://www.analyticsflow.cz/sluzby</loc>
-    <lastmod>2025-06-29T19:19:46.000Z</lastmod>
+    <lastmod>2025-05-26T11:51:05.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
- Update cookieConsentUtils.ts for granular categories (essential, analytics, marketing, preferences) and versioning.
- Create CookieCustomizationModal.tsx for user selection of cookie categories.
- Integrate customization modal into CookieConsentBanner.tsx.
- Refactor app/layout.tsx to manage banner display and GTM consent updates based on new granular structure.